### PR TITLE
[WiP]Remove redundant calls in unit tests

### DIFF
--- a/src/components/application_manager/test/commands/mobile/add_sub_menu_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/add_sub_menu_request_test.cc
@@ -90,6 +90,11 @@ class AddSubMenuRequestTest
     ON_CALL(hmi_interfaces_, GetInterfaceFromFunction(_))
         .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
   }
+
+  void TearDown() OVERRIDE {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+
   MockAppPtr app;
   MessageSharedPtr command_msg_;
 
@@ -147,7 +152,6 @@ TEST_F(AddSubMenuRequestTest, OnEvent_UI_UNSUPPORTED_RESOURCE) {
             .asString()
             .empty());
   }
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 TEST_F(AddSubMenuRequestTest, OnEvent_SUCCESS) {
@@ -283,9 +287,6 @@ TEST_F(AddSubMenuRequestTest, Run_SUCCESS) {
   EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
   EXPECT_CALL(*app, FindSubMenu(kMenuId)).WillOnce(ReturnNull());
 
-  EXPECT_CALL(mock_message_helper_,
-              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
-      .WillOnce(Return(mobile_apis::Result::SUCCESS));
   AddSubMenuPtr command(CreateCommand<AddSubMenuRequest>(command_msg_));
   MessageSharedPtr result_msg(CatchHMICommandResult(CallRun(*command)));
   const hmi_apis::FunctionID::eType received_result =
@@ -304,16 +305,9 @@ TEST_F(AddSubMenuRequestTest, Run_MenuIconCorrectName_SUCCESS) {
   (*command_msg_)[am::strings::msg_params][am::strings::sub_menu_icon]
                  [am::strings::type] = "DYNAMIC";
 
-  EXPECT_CALL(mock_message_helper_,
-              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
-      .WillOnce(Return(mobile_apis::Result::SUCCESS));
   AddSubMenuPtr command(CreateCommand<AddSubMenuRequest>(command_msg_));
   EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
   EXPECT_CALL(*app, FindSubMenu(kMenuId)).WillOnce(ReturnNull());
-
-  EXPECT_CALL(mock_message_helper_,
-              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
-      .WillOnce(Return(mobile_apis::Result::SUCCESS));
 
   MessageSharedPtr result_msg(CatchHMICommandResult(CallRun(*command)));
   const hmi_apis::FunctionID::eType received_result =
@@ -335,9 +329,6 @@ TEST_F(AddSubMenuRequestTest, Run_MenuIconNewLineChar_SendWithoutIcon) {
   EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
   EXPECT_CALL(*app, FindSubMenu(kMenuId)).WillOnce(ReturnNull());
 
-  EXPECT_CALL(mock_message_helper_,
-              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
-      .WillOnce(Return(mobile_apis::Result::SUCCESS));
   AddSubMenuPtr command(CreateCommand<AddSubMenuRequest>(command_msg_));
   MessageSharedPtr result_msg(CatchHMICommandResult(CallRun(*command)));
   const hmi_apis::FunctionID::eType received_result =
@@ -357,9 +348,6 @@ TEST_F(AddSubMenuRequestTest, Run_MenuIconTabChar_SendWithoutIcon) {
 
   EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
   EXPECT_CALL(*app, FindSubMenu(kMenuId)).WillOnce(ReturnNull());
-  EXPECT_CALL(mock_message_helper_,
-              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
-      .WillOnce(Return(mobile_apis::Result::SUCCESS));
 
   AddSubMenuPtr command(CreateCommand<AddSubMenuRequest>(command_msg_));
   MessageSharedPtr result_msg(CatchHMICommandResult(CallRun(*command)));
@@ -380,9 +368,6 @@ TEST_F(AddSubMenuRequestTest, Run_MenuIconWhiteSpace_SendWithoutIcon) {
 
   EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
   EXPECT_CALL(*app, FindSubMenu(kMenuId)).WillOnce(ReturnNull());
-  EXPECT_CALL(mock_message_helper_,
-              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
-      .WillOnce(Return(mobile_apis::Result::SUCCESS));
 
   AddSubMenuPtr command(CreateCommand<AddSubMenuRequest>(command_msg_));
   MessageSharedPtr result_msg(CatchHMICommandResult(CallRun(*command)));


### PR DESCRIPTION
Not merge until PR [#953](https://github.com/smartdevicelink/sdl_core/pull/953) is testing.
Related to APPLINK-23382